### PR TITLE
Fix empty user input

### DIFF
--- a/lib/userLoop.js
+++ b/lib/userLoop.js
@@ -27,7 +27,8 @@ const userLoop = (name, colour = false) => {
             .reverse()
             .join("");
 
-          console.log(colour ? chalk.hex('#13C4AC')(msg) : msg);
+          console.log(customPrint({ text: msg, colour: '#13C4AC', colourBoolean: colour }));
+
           if (isPalindrome(line)) {
             console.log(customPrint({text: '¡Bonita palabra!', colour: '#3E95F3', colourBoolean: colour}));
           }

--- a/test/userLoop.test.js
+++ b/test/userLoop.test.js
@@ -4,7 +4,7 @@ const mockStdin = require('mock-stdin').stdin();
 
 const userLoop = require('../lib/userLoop');
 
-describe.only('userLoop', () => {
+describe('userLoop', () => {
   let consoleLogStub;
   let processExitStub;
 
@@ -38,6 +38,11 @@ describe.only('userLoop', () => {
     assert.strictEqual(consoleLogStub.getCall(1).lastArg, '¡Bonita palabra!');
   });
 
+  it('should show the prompt again if the user presses ENTER without introducing any input', () => {
+    mockStdin.send('\n');
+    assert(consoleLogStub.notCalled);
+  });
+
   it('should echo \'Adios user name\' and exit when the user dispatches an end event', () => {
     assert.throws(
       () => {
@@ -50,10 +55,5 @@ describe.only('userLoop', () => {
     );
     assert(consoleLogStub.calledOnce);
     assert.strictEqual(consoleLogStub.getCall(0).lastArg, 'Adios user name');
-  });
-
-  it.only('should show the prompt again if the user presses ENTER without introducing any input', () => {
-    mockStdin.send('\n');
-    assert(consoleLogStub.notCalled);
   });
 });


### PR DESCRIPTION
### Type:
* [X] fix: test case and logic when the user doesn't introduce any input.

### What's the focus of this PR:
- There was a bug when the user pressed enter. The app detected a palindrome, since the input was empty. It has been fixed to show the prompt again without any message.

### How to review this PR:
- New test case for userLoop and logic added to the method.
